### PR TITLE
Add trigger delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 .classpath
 .project
 .settings/
-
+.idea
+*.iml

--- a/src/main/java/com/fiestacabin/dropwizard/quartz/ManagedScheduler.java
+++ b/src/main/java/com/fiestacabin/dropwizard/quartz/ManagedScheduler.java
@@ -5,6 +5,7 @@ import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 import io.dropwizard.lifecycle.Managed;
 
+import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -63,9 +64,10 @@ public class ManagedScheduler implements Managed {
 			trigger.withSchedule(CronScheduleBuilder.cronSchedule(ann.cron()).inTimeZone(config.getTimezone()));
 		} else if (ann.interval() != -1) {
 			trigger.withSchedule(simpleSchedule()
-					.withIntervalInMilliseconds(
-							TimeUnit.MILLISECONDS.convert(ann.interval(), ann.unit()))
-					.repeatForever()).startNow();
+                    .withIntervalInMilliseconds(
+                            TimeUnit.MILLISECONDS.convert(ann.interval(), ann.unit()))
+                    .repeatForever())
+                    .startAt(new Date(System.currentTimeMillis() + ann.delayInMillis()));
 		} else {
 			throw new IllegalArgumentException("One of 'cron', 'interval' is required for the @Scheduled annotation");
 		}

--- a/src/main/java/com/fiestacabin/dropwizard/quartz/Scheduled.java
+++ b/src/main/java/com/fiestacabin/dropwizard/quartz/Scheduled.java
@@ -12,5 +12,6 @@ import java.util.concurrent.TimeUnit;
 public @interface Scheduled {
 	String cron() default "";
 	int interval() default -1;
+	int delayInMillis() default 0;
 	TimeUnit unit() default TimeUnit.SECONDS;
 }


### PR DESCRIPTION
Replace startNow by startAt which uses the de delay option in the annotation
to delay the first job execution to avoid jobs executing before the dropwizard
application is fully booted.
